### PR TITLE
Python2 to Python3

### DIFF
--- a/FocusStack.py
+++ b/FocusStack.py
@@ -69,13 +69,13 @@ def align_images(images):
         detector = cv2.ORB_create(1000)
 
     #   We assume that image 0 is the "base" image and align everything to it
-    print "Detecting features of base image"
+    print("Detecting features of base image")
     outimages.append(images[0])
     image1gray = cv2.cvtColor(images[0],cv2.COLOR_BGR2GRAY)
     image_1_kp, image_1_desc = detector.detectAndCompute(image1gray, None)
 
     for i in range(1,len(images)):
-        print "Aligning image {}".format(i)
+        print("Aligning image {}".format(i))
         image_i_kp, image_i_desc = detector.detectAndCompute(images[i], None)
 
         if use_sift:
@@ -126,10 +126,10 @@ def doLap(image):
 def focus_stack(unimages):
     images = align_images(unimages)
 
-    print "Computing the laplacian of the blurred images"
+    print("Computing the laplacian of the blurred images")
     laps = []
     for i in range(len(images)):
-        print "Lap {}".format(i)
+        print("Lap {}".format(i))
         laps.append(doLap(cv2.cvtColor(images[i],cv2.COLOR_BGR2GRAY)))
 
     laps = np.asarray(laps)

--- a/FocusStack.py
+++ b/FocusStack.py
@@ -133,7 +133,7 @@ def focus_stack(unimages):
         laps.append(doLap(cv2.cvtColor(images[i],cv2.COLOR_BGR2GRAY)))
 
     laps = np.asarray(laps)
-    print "Shape of array of laplacians = {}".format(laps.shape)
+    print("Shape of array of laplacians = {}".format(laps.shape))
 
     output = np.zeros(shape=images[0].shape, dtype=images[0].dtype)
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ import FocusStack
 def stackHDRs(image_files):
     focusimages = []
     for img in image_files:
-        print "Reading in file {}".format(img)
+        print("Reading in file {}".format(img))
         focusimages.append(cv2.imread("input/{}".format(img)))
 
     merged = FocusStack.focus_stack(focusimages)
@@ -34,4 +34,4 @@ if __name__ == "__main__":
 
 
     stackHDRs(image_files)
-    print "That's All Folks!"
+    print("That's All Folks!")

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import FocusStack
     Focus stack driver program
 
     This program looks for a series of files of type .jpg, .jpeg, or .png
-    in a subdirectory "input" and then merges them together using the
+    in a subdirectory "Input" and then merges them together using the
     FocusStack module.  The output is put in the file merged.png
 
 
@@ -20,7 +20,7 @@ def stackHDRs(image_files):
     focusimages = []
     for img in image_files:
         print("Reading in file {}".format(img))
-        focusimages.append(cv2.imread("input/{}".format(img)))
+        focusimages.append(cv2.imread("Input/{}".format(img)))
 
     merged = FocusStack.focus_stack(focusimages)
     cv2.imwrite("merged.png", merged)

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def stackHDRs(image_files):
 
 
 if __name__ == "__main__":
-    image_files = sorted(os.listdir("input"))
+    image_files = sorted(os.listdir("Input"))
     for img in image_files:
         if img.split(".")[-1].lower() not in ["jpg", "jpeg", "png"]:
             image_files.remove(img)


### PR DESCRIPTION
- Fixed `print` syntax from Python2 to Python3
- Fixed input folder name from `'input'` to `'Input'`