### PR TITLE
Updated cv2 SIFT and ORB statements for compatibility.

### DIFF
--- a/FocusStack.py
+++ b/FocusStack.py
@@ -64,18 +64,18 @@ def align_images(images):
     outimages = []
 
     if use_sift:
-        detector = cv2.xfeatures2d.SIFT_create()
+        detector = cv2.SIFT.create()
     else:
-        detector = cv2.ORB_create(1000)
+        detector = cv2.ORB.create(1000)
 
     #   We assume that image 0 is the "base" image and align everything to it
-    print "Detecting features of base image"
+    print("Detecting features of base image")
     outimages.append(images[0])
     image1gray = cv2.cvtColor(images[0],cv2.COLOR_BGR2GRAY)
     image_1_kp, image_1_desc = detector.detectAndCompute(image1gray, None)
 
     for i in range(1,len(images)):
-        print "Aligning image {}".format(i)
+        print("Aligning image {}".format(i))
         image_i_kp, image_i_desc = detector.detectAndCompute(images[i], None)
 
         if use_sift:
@@ -126,14 +126,14 @@ def doLap(image):
 def focus_stack(unimages):
     images = align_images(unimages)
 
-    print "Computing the laplacian of the blurred images"
+    print("Computing the laplacian of the blurred images")
     laps = []
     for i in range(len(images)):
-        print "Lap {}".format(i)
+        print("Lap {}".format(i))
         laps.append(doLap(cv2.cvtColor(images[i],cv2.COLOR_BGR2GRAY)))
 
     laps = np.asarray(laps)
-    print "Shape of array of laplacians = {}".format(laps.shape)
+    print("Shape of array of laplacians = {}".format(laps.shape))
 
     output = np.zeros(shape=images[0].shape, dtype=images[0].dtype)
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ import FocusStack
 def stackHDRs(image_files):
     focusimages = []
     for img in image_files:
-        print "Reading in file {}".format(img)
+        print("Reading in file {}".format(img))
         focusimages.append(cv2.imread("input/{}".format(img)))
 
     merged = FocusStack.focus_stack(focusimages)
@@ -34,4 +34,4 @@ if __name__ == "__main__":
 
 
     stackHDRs(image_files)
-    print "That's All Folks!"
+    print("That's All Folks!")


### PR DESCRIPTION
Updated lines below for compatibility with opencv-python v 4.9.0.80.

Before: cv2.xfeatures2d.SIFT_create()
After: cv2.SIFT.create()

Before: cv2.ORB_create(1000)
After: cv2.ORB.create(1000)

also updated print statement formatting.